### PR TITLE
Allow for opening classes or members in vs code

### DIFF
--- a/src/components/ClassNode.jsx
+++ b/src/components/ClassNode.jsx
@@ -9,8 +9,10 @@ import Tooltip from '@mui/material/Tooltip';
 import PaletteIcon from '@mui/icons-material/Palette';
 import ClassIcon from '@mui/icons-material/Class';
 import PublicOffIcon from '@mui/icons-material/PublicOff';
+import EditIcon from '@mui/icons-material/Edit';
 import { Handle, Position } from 'reactflow';
 import { GetModelAccess, GetModelStatic, GetModelFinal, GetModelAbstract } from '../structures/classModels';
+import { os, filesystem } from "@neutralinojs/lib";
 
 // Function to determine the color class based on attribute type
 function getAttributeType(type) {
@@ -147,18 +149,25 @@ const ClassNode = memo(({ data, isConnectable }) => {
           </div>
         </div>
         <div className= "bg-gray-900 rounded-xl flex-grow flex flex-col mt-7">
-          <button value={data.classIndex} className="items-center flex border-2 border-white m-2 rounded-xl bg-yellow-700 font-small text-white font-bold w-[40%] p-1"
+          <div className= "flex flex-row">
+            <button value={data.classIndex} className="items-center flex border-2 border-white m-2 rounded-xl bg-yellow-700 font-small text-white font-bold w-[40%] p-1"
             onClick={data.onClick}>&nbsp;
               {getClasAccess(GetModelAccess(data.classData))}&nbsp;
               {getClasAccess(data.classData)}
               {data.classData.name}
           </button>
+          <button className="items-center flex border-2 border-white m-2 rounded-xl bg-gray-700 font-small text-white font-bold p-1" onClick={ () => os.execCommand('code -g "' + data.classData.filePath + '":' + data.classData.line) }>
+            <Tooltip title="Edit">
+              <EditIcon fontSize='small'className='rounded-xl bg-white-500 hover:' />
+            </Tooltip>
+          </button>
+          </div>
           <div className="flex items-center">
             <p className='font-bold text-[16px] mr-2 mt-2 ml-1'>ATTRIBUTES</p>
           </div>
           <div className="ml-2" style={{ textAlign: "left", fontSize: "15px" }}>
             {data.classData.attributes.map((attribute, index) => (
-              <span className={`label inline-block rounded-xl ${getAttributeType(attribute.type)} mr-1 p-[2px] items-center justify-center`} key={index}>  &nbsp;
+              <span onClick={ () => os.execCommand('code -g "' + data.classData.filePath + '":' + attribute.line) } className={`label inline-block rounded-xl ${getAttributeType(attribute.type)} mr-1 p-[2px] items-center justify-center`} key={index}>  &nbsp;
               {getAccessTypeIcon(GetModelAccess(attribute))}
               {getFinalOrStatic(GetModelStatic(attribute), GetModelFinal(attribute))}
               &nbsp;{attribute.name} &nbsp; </span>
@@ -169,7 +178,7 @@ const ClassNode = memo(({ data, isConnectable }) => {
           </div>
           <div className="ml-2" style={{ textAlign: "left", fontSize: "15px" }}>
             {data.classData.methods.map((method, index) => (
-              <span className={`label inline-block rounded-xl ${getAttributeType(method.type)} mr-1 p-[2px] items-center justify-center`} key={index}>  &nbsp;
+              <span onClick={ () => os.execCommand('code -g "' + data.classData.filePath + '":' + method.line) } className={`label inline-block rounded-xl ${getAttributeType(method.type)} mr-1 p-[2px] items-center justify-center`} key={index}>  &nbsp;
               {getAccessTypeIcon(GetModelAccess(method))}
               {getFinalOrStatic(GetModelStatic(method), GetModelFinal(method))}
               &nbsp;{method.name} &nbsp; </span>

--- a/src/components/CloseableTab.jsx
+++ b/src/components/CloseableTab.jsx
@@ -9,6 +9,7 @@ import './ClassNode.css';
 import dagre from 'dagre';
 import ClassInspector from './ClassInspector';
 import ReactFlow, { Controls, Background, useNodesState, useEdgesState, MarkerType } from 'reactflow';
+import { os, filesystem } from "@neutralinojs/lib";
 
 // Node types
 const nodeTypes = {

--- a/src/logic/folderUtils.ts
+++ b/src/logic/folderUtils.ts
@@ -4,37 +4,46 @@ import { os, filesystem } from "@neutralinojs/lib"
 
 import { LocateClasses } from './parser';
 import { JavaTokenizer } from './lexers';
+import { FileModel } from '../structures/filesystemModels'
 
 /**
  * Opens dialog for the user to select a directory for a java project, and then reads in the contents 
  * of each java file within
+ * 
+ * @returns {Promise<ClassModel[]>} - The classes found in the directory as a list of ClassModels
  */
-export async function RetrieveJavaClassModelBySelectingProjectDirectory(): ClassModel[] {
+export async function RetrieveJavaClassModelBySelectingProjectDirectory(): Promise<ClassModel[]> {
   let projectDir: string = await os.showFolderDialog('Open a project Directory', {});
-  let code = await GetRecursiveContentsOfDirectoryByExtension(projectDir, "java");
-  const tokenizer = new JavaTokenizer(code);
-  let tokens = [];
-  let token = tokenizer.getNextToken();
-  while (token !== null) {
-      tokens.push(token);
-      token = tokenizer.getNextToken();
+  let files = await GetRecursiveContentsOfDirectoryByExtension(projectDir, "java");
+  let classes: FileModel[] = [];
+  for (const file of files) {
+    const tokenizer = new JavaTokenizer(file.content);
+    let tokens = [];
+    let token = tokenizer.getNextToken();
+    while (token !== null) {
+        tokens.push(token);
+        token = tokenizer.getNextToken();
+    }
+    let fileClasses = LocateClasses(tokens);
+    fileClasses.forEach(cl => {
+      cl.filePath = file.path;
+    });
+    classes.push(...fileClasses);
   }
-  let classes = LocateClasses(tokens);
-  console.log(classes);
   return classes;
 }
 
 /**
- * Returns the contents of all files within a directory that have the specified extension as a string
+ * Returns all files within a directory that have the specified extension as a string
  * @param {string} dir - The directory to look through
  * @param {string} extension - The extension to look for
  * 
- * @returns {Promise<string>} - A string of the contents of each file concatenated together
+ * @returns {Promise<FileModel[]>} - The files in the directory
  */
-export async function GetRecursiveContentsOfDirectoryByExtension(dir: string, extension: string): Promise<string> {
+export async function GetRecursiveContentsOfDirectoryByExtension(dir: string, extension: string): Promise<FileModel[]> {
   let items: string[][] = await GetItemsInDirectoryRecursive(dir, extension);
-  let fileStr: string = await ReadFilesToString(items[0]);
-  return fileStr;
+  let fileArr = await ReadFiles(items[0]);
+  return fileArr;
 }
 
 /**
@@ -105,18 +114,21 @@ async function GetItemsInDirectoryRecursive (dir: string, extension: string = ""
 }
 
 /**
- * Takes in a list of strings of file paths and returns the contents of all files as a string
+ * Takes in a list of strings of file paths and returns the files as FileModels
  *
  * @param {string[]} files - An array of the file paths
  * 
- * @returns {Promise<string>} - The content of the file as a string
+ * @returns {Promise<FileModel>} - The file
  */
-export async function ReadFilesToString(files: string[]): Promise<string> {
-  let fileStr: string = "";
+export async function ReadFiles(files: string[]): Promise<FileModel> {
+  let ret: FileModel = [];
   for (const file of files) {
-    fileStr += await filesystem.readFile(file, {pos:0, size: 100000}) + "\n";
+    ret.push({
+        path: file, 
+        content: await filesystem.readFile(file, {pos:0, size: 100000})
+      });
   }
-  return fileStr;
+  return ret;
 }
 
 /**

--- a/src/logic/lexers.ts
+++ b/src/logic/lexers.ts
@@ -1,5 +1,5 @@
 export class Token {
-    constructor(public type: string, public value: string | null) { }
+    constructor(public type: string, public value: string | null, public line: number) { }
 }
 
 const KEYWORDS = ["abstract", "boolean", "break", "byte", "case", "catch", "char", "class", "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "if", "implements", "import", "instanceof", "int", "interface", "long", "new", "package", "private", "protected", "public", "return", "short", "static", "super", "switch", "this", "throw", "throws", "try", "void", "while"];
@@ -8,6 +8,7 @@ export class JavaTokenizer {
     private code: string;
     private index: number = 0;
     private lastToken: Token | null = null;
+    private line: number = 1;
 
     constructor(code: string) {
         this.code = code;
@@ -62,6 +63,9 @@ export class JavaTokenizer {
     private readWhile(predicate: (char: string) => boolean): string {
         let result = '';
         while (this.code[this.index] !== undefined && predicate(this.code[this.index])) {
+            if (this.code[this.index] === "\n") {
+                this.line ++;
+            }
             result += this.readCurrent();
         }
         return result;
@@ -70,40 +74,40 @@ export class JavaTokenizer {
     private readIdentifier(): Token {
         const value = this.readWhile((char) => this.isIdentifierStart(char) || this.isDigit(char));
         const type = KEYWORDS.includes(value) ? 'KEYWORD' : 'IDENTIFIER';
-        this.lastToken = new Token(type, value);
-        return new Token(type, value);
+        this.lastToken = new Token(type, value, this.line);
+        return new Token(type, value, this.line);
     }
 
     private readNumber(): Token {
         const value = this.readWhile((char) => this.isDigit(char) || char === ".");
-        this.lastToken = new Token('NUMBER', value);
-        return new Token('NUMBER', value);
+        this.lastToken = new Token('NUMBER', value, this.line);
+        return new Token('NUMBER', value, this.line);
     }
 
     private readQuote(): Token {
         // Quotes are only 1 character, so don't want to treat multiple quotes next to it as the same token
         const value = this.readCurrent();
         let tokenType = this.lastToken.type === "STRING" ? 'ENDQUOTES' : 'QUOTES';
-        this.lastToken = new Token(tokenType, value);
-        return new Token(tokenType, value);
+        this.lastToken = new Token(tokenType, value, this.line);
+        return new Token(tokenType, value, this.line);
     }
 
     private readOperator(): Token {
         const value = this.readWhile((char) => this.isOperator(char));
-        this.lastToken = new Token('OPERATOR', value);
-        return new Token('OPERATOR', value);
+        this.lastToken = new Token('OPERATOR', value, this.line);
+        return new Token('OPERATOR', value, this.line);
     }
 
     private readCurlyBrace(): Token {
         const value = this.readWhile((char) => this.isCurlyBrace(char));
-        this.lastToken = new Token('CURLY_BRACE', value);
-        return new Token('CURLY_BRACE', value);
+        this.lastToken = new Token('CURLY_BRACE', value, this.line);
+        return new Token('CURLY_BRACE', value, this.line);
     }
 
     private readSingleLineComment(): Token {
         const value = this.readWhile((char) => char !== '\n' && char !== '\r');
-        this.lastToken = new Token('COMMENT', value);
-        return new Token('COMMENT', value);
+        this.lastToken = new Token('COMMENT', value, this.line);
+        return new Token('COMMENT', value, this.line);
     }
 
     private readMultiLineComment(): Token {
@@ -116,22 +120,22 @@ export class JavaTokenizer {
             }
             value += char;
         }
-        this.lastToken = new Token('COMMENT', value);
-        return new Token('COMMENT', value);
+        this.lastToken = new Token('COMMENT', value, this.line);
+        return new Token('COMMENT', value, this.line);
     }
 
     private readOther(): Token {
         const value = this.code[this.index];
         this.index++;
-        this.lastToken = new Token('OTHER', value);
-        return new Token('OTHER', value);
+        this.lastToken = new Token('OTHER', value, this.line);
+        return new Token('OTHER', value, this.line);
     }
 
     private readString(): Token {
         const quote = this.lastToken.value;
         const value = this.readWhile((char) => char !== quote);
-        this.lastToken = new Token('STRING', value);
-        return new Token('STRING', value);
+        this.lastToken = new Token('STRING', value, this.line);
+        return new Token('STRING', value, this.line);
     }
 
     private skipWhitespace(): void {
@@ -143,7 +147,7 @@ export class JavaTokenizer {
     }
 
     getNextToken(): Token | null {
-
+        
         if (!this.isString()) {
             this.skipWhitespace();
         }

--- a/src/logic/parser.ts
+++ b/src/logic/parser.ts
@@ -105,7 +105,7 @@ export function LocateClasses(tokens: Token[]): ClassModel[] {
         }
         // If we run into a class modifier, or the class or interface keywords, this is a class definition, and we should start gathering the symbols
         else if (IsClassModifier(tokens[index]) || IsClassKeyword(tokens[index])) {
-            let model: ClassModel = {modifiers: [], generics: [], interface: false, name: "", extends: "", implements: [], attributes: [], methods: []};
+            let model: ClassModel = {modifiers: [], generics: [], interface: false, name: "", extends: "", implements: [], attributes: [], methods: [], filePath: "", line: tokens[index].line};
             // Gather modifiers
             while (index < tokens.length && IsClassModifier(tokens[index])) {
                 model.modifiers.push(tokens[index].value);
@@ -197,6 +197,7 @@ export function LocateMembers(tokens: Token[]): Members {
         if (tokens[index].value === "@") {
             index = SkipAnnotation(tokens, index);
         } else if (IsMemberModifier(tokens[index]) || tokens[index].type === "KEYWORD") {
+            let line = tokens[index].line;
             while (index < tokens.length && IsMemberModifier(tokens[index])) {
                 modifierTokens.push(tokens[index]);
                 index ++;
@@ -254,7 +255,8 @@ export function LocateMembers(tokens: Token[]): Members {
                     return: typeTokens.map((t) => t.value).toString().replaceAll(",", ""), 
                     name: nameToken.value, 
                     parameters: [],
-                    generics: []
+                    generics: [],
+                    line: line
                 });
             }
             // Semicolon here means that this is the end of an attribute definition
@@ -264,7 +266,8 @@ export function LocateMembers(tokens: Token[]): Members {
                     modifiers: [...modifierTokens.map((t) => t.value)], 
                     type: typeTokens.map((t) => t.value).toString().replaceAll(",", ""), 
                     name: nameToken.value, 
-                    value: valueTokens.map((t) => t.value).toString().replaceAll(",", "")
+                    value: valueTokens.map((t) => t.value).toString().replaceAll(",", ""),
+                    line: line
                 });
             }
         } else {

--- a/src/structures/classModels.ts
+++ b/src/structures/classModels.ts
@@ -4,14 +4,16 @@ export interface VariableModel {
     name: string,
     value: string,
     type: string,
-    modifiers: string[]
+    modifiers: string[],
+    line: number
 }
 export interface MethodModel {
     name: string,
     parameters: VariableModel[],
     return: string,
     modifiers: string[],
-    generics: string[]
+    generics: string[],
+    line: number
 }
 export interface ClassModel {
     name: string,
@@ -21,7 +23,9 @@ export interface ClassModel {
     extends: string,
     implements: string[],
     modifiers: string[],
-    generics: string[]
+    generics: string[],
+    filePath: string,
+    line: number
 }
 export interface Members {
     attributes: VariableModel[],

--- a/src/structures/filesystemModels.ts
+++ b/src/structures/filesystemModels.ts
@@ -1,0 +1,4 @@
+export interface FileModel {
+    path: string,
+    content: string
+}


### PR DESCRIPTION
Adds an edit button beside the class name on a class node:
![image](https://github.com/mddvisu/raven/assets/105814224/c1969e41-00a5-4006-93e2-33c4f55bc319)
When clicked, it will open the class file in VS Code

Users can now also click on members shown on the class node to open the location in the code where that member is defined

To accomplish this, I changed the lexer so that tokens now track what line they are located on, and also altered fileUtils and the parser to make it so each ClassModel will keep track of the file the class is in, as well as the line it is on. MethodModels and VariableModels also now have another line field